### PR TITLE
Login Hint on Practice Link

### DIFF
--- a/CodeLingo.Frontend/src/app/app.module.ts
+++ b/CodeLingo.Frontend/src/app/app.module.ts
@@ -36,6 +36,7 @@ import { QuestionContainerComponent } from './question-container/question-contai
 import { QuestionProgressComponent } from './question-container/question-progress/question-progress.component';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { jwtInterceptor } from './jwt.interceptor';
+import { TooltipDirective } from './shared/directives/tooltip.directive';
 
 @NgModule({
   declarations: [
@@ -69,6 +70,7 @@ import { jwtInterceptor } from './jwt.interceptor';
     CodeCompletionQuestionComponent,
     QuestionContainerComponent,
     QuestionProgressComponent,
+    TooltipDirective,
   ],
   imports: [
     BrowserModule,

--- a/CodeLingo.Frontend/src/app/footer/footer.component.html
+++ b/CodeLingo.Frontend/src/app/footer/footer.component.html
@@ -12,7 +12,9 @@
                 <ul class="list-unstyled d-flex flex-column gap-2">
                     <li><a routerLink="landing-page" class="text-dark text-decoration-none">
                             Home</a></li>
-                    <li><a routerLink="practice/start" class="text-dark text-decoration-none ">
+                    <li><a routerLink="practice/start" class="text-dark text-decoration-none "
+                            [appTooltip]="(isLoggedIn$ | async) ? '' : 'Please log in to start practicing!'"
+                            [class.disabled-link]="!(isLoggedIn$ | async)" (click)="handlePracticeClick($event)">
                             Practice</a></li>
                     <li><a routerLink="leaderboard" class="text-dark text-decoration-none">
                             Leaderboard</a></li>
@@ -25,7 +27,7 @@
                     </a> Follow us
                 </h5>
             </div>
-                <p class="text-dark">© 2025 Codelingo Team</p>
+            <p class="text-dark">© 2025 Codelingo Team</p>
         </div>
 
     </div>

--- a/CodeLingo.Frontend/src/app/footer/footer.component.ts
+++ b/CodeLingo.Frontend/src/app/footer/footer.component.ts
@@ -1,4 +1,6 @@
 import { Component } from '@angular/core';
+import { AuthService } from '../services/auth/auth.service';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-footer',
@@ -7,5 +9,16 @@ import { Component } from '@angular/core';
   styleUrl: './footer.component.scss'
 })
 export class FooterComponent {
+  isLoggedIn$!: Observable<boolean>;
 
+  constructor(private auth: AuthService) {
+    this.isLoggedIn$ = this.auth.isLoggedIn$;
+  }
+
+  handlePracticeClick(event: Event) {
+    if (!this.auth.hasValidToken()) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  }
 }

--- a/CodeLingo.Frontend/src/app/header/header.component.html
+++ b/CodeLingo.Frontend/src/app/header/header.component.html
@@ -22,8 +22,9 @@
           </a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" routerLink="/practice/start" [class.disabled]="!(isLoggedIn$ | async)"
-            [attr.aria-disabled]="!(isLoggedIn$ | async)" (click)="closeMobileMenu()">
+          <a class="nav-link" routerLink="/practice/start" [class.disabled-link]="!(isLoggedIn$ | async)"
+            [appTooltip]="(isLoggedIn$ | async) ? '' : 'Please log in to start practicing!'"
+            (click)="handlePracticeClick($event); closeMobileMenu()">
             <i class="bi bi-arrow-right-circle-fill"></i>
             Practice
           </a>

--- a/CodeLingo.Frontend/src/app/header/header.component.ts
+++ b/CodeLingo.Frontend/src/app/header/header.component.ts
@@ -43,6 +43,13 @@ export class HeaderComponent {
     this.auth.logout();
   }
 
+  handlePracticeClick(event: Event) {
+    if (!this.auth.hasValidToken()) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  }
+
   toggleMobileMenu() {
     this.isMobileMenuOpen = !this.isMobileMenuOpen;
   }

--- a/CodeLingo.Frontend/src/app/shared/directives/tooltip.directive.ts
+++ b/CodeLingo.Frontend/src/app/shared/directives/tooltip.directive.ts
@@ -1,0 +1,63 @@
+import { Directive, ElementRef, HostListener, Input, Renderer2, OnDestroy } from '@angular/core';
+
+@Directive({
+    selector: '[appTooltip]',
+    standalone: false
+})
+export class TooltipDirective implements OnDestroy {
+    @Input('appTooltip') tooltipText: string = '';
+    private tooltipElement: HTMLElement | null = null;
+    private showTimeout: any;
+
+    constructor(private el: ElementRef, private renderer: Renderer2) { }
+
+    @HostListener('mouseenter') onMouseEnter() {
+        if (!this.tooltipText) return;
+        this.showTimeout = setTimeout(() => {
+            this.showTooltip();
+        }, 200); // Small delay
+    }
+
+    @HostListener('mouseleave') onMouseLeave() {
+        this.hideTooltip();
+    }
+
+    @HostListener('click') onClick() {
+        this.hideTooltip();
+    }
+
+    private showTooltip() {
+        if (this.tooltipElement) return;
+
+        this.tooltipElement = this.renderer.createElement('div');
+        this.renderer.addClass(this.tooltipElement, 'custom-tooltip');
+        const text = this.renderer.createText(this.tooltipText);
+        this.renderer.appendChild(this.tooltipElement, text);
+        this.renderer.appendChild(document.body, this.tooltipElement);
+
+        const hostPos = this.el.nativeElement.getBoundingClientRect();
+        const tooltipPos = this.tooltipElement!.getBoundingClientRect();
+
+        const top = hostPos.bottom + 8; // Position below
+        const left = hostPos.left + (hostPos.width - tooltipPos.width) / 2;
+
+        this.renderer.setStyle(this.tooltipElement, 'top', `${top}px`);
+        this.renderer.setStyle(this.tooltipElement, 'left', `${left}px`);
+        this.renderer.setStyle(this.tooltipElement, 'opacity', '1');
+    }
+
+    private hideTooltip() {
+        if (this.showTimeout) {
+            clearTimeout(this.showTimeout);
+            this.showTimeout = null;
+        }
+        if (this.tooltipElement) {
+            this.renderer.removeChild(document.body, this.tooltipElement);
+            this.tooltipElement = null;
+        }
+    }
+
+    ngOnDestroy() {
+        this.hideTooltip();
+    }
+}

--- a/CodeLingo.Frontend/src/styles.scss
+++ b/CodeLingo.Frontend/src/styles.scss
@@ -4,14 +4,33 @@
 // Import variables (this won't generate CSS, just makes variables available)
 @import 'variables';
 
-
-
 // Global typography styles
-h1, .h1 { font-weight: $font-weight-extrabold; }
-h2, .h2 { font-weight: $font-weight-extrabold; }
-h3, .h3 { font-weight: $font-weight-bold; }
-h4, .h4 { font-weight: $font-weight-semibold; }
-h5, .h5, h6, .h6 { font-weight: $font-weight-regular; }
+h1,
+.h1 {
+  font-weight: $font-weight-extrabold;
+}
+
+h2,
+.h2 {
+  font-weight: $font-weight-extrabold;
+}
+
+h3,
+.h3 {
+  font-weight: $font-weight-bold;
+}
+
+h4,
+.h4 {
+  font-weight: $font-weight-semibold;
+}
+
+h5,
+.h5,
+h6,
+.h6 {
+  font-weight: $font-weight-regular;
+}
 
 // Caption text
 .caption {
@@ -21,7 +40,9 @@ h5, .h5, h6, .h6 { font-weight: $font-weight-regular; }
 }
 
 // Code blocks
-code, pre, .code {
+code,
+pre,
+.code {
   font-family: $font-family-monospace;
   font-size: 1.5rem;
   line-height: 1.4;
@@ -30,3 +51,35 @@ code, pre, .code {
 // Import Bootstrap with our custom theme
 @import "bootstrap/scss/bootstrap";
 @import "bootstrap-icons/font/bootstrap-icons.css";
+
+// Custom Tooltip
+.custom-tooltip {
+  position: fixed;
+  z-index: 10000;
+  background-color: $dark;
+  color: $white;
+  padding: 0.5rem 1rem;
+  border-radius: 0.25rem;
+  font-size: 0.875rem;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  border: 1px solid $primary;
+
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: transparent transparent $primary transparent;
+  }
+}
+
+.disabled-link {
+  opacity: 0.6;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
This update adds a custom tooltip that appears when unauthenticated users hover over the “Practice” link in both the header and footer. A new TooltipDirective handles the display logic and styling, and related tooltip styles were added globally. The header and footer templates were updated to use the directive and apply a disabled visual state, while click handlers were introduced to prevent navigation when the user is not logged in. Logged-in users see no tooltip and can access the practice page normally.