### PR TITLE
Conditionally displays estimated time

### DIFF
--- a/CodeLingo.Frontend/src/app/question-container/multiple-choice-question/multiple-choice-question.component.html
+++ b/CodeLingo.Frontend/src/app/question-container/multiple-choice-question/multiple-choice-question.component.html
@@ -14,7 +14,7 @@
         <i class="bi bi-bar-chart-fill"></i>
         {{ question.difficulty | titlecase }}
       </span>
-      <span class="meta-item">
+      <span class="meta-item" *ngIf="question.metadata.estimatedTimeSeconds">
         <i class="bi bi-clock"></i>
         {{ question.metadata.estimatedTimeSeconds }}s
       </span>


### PR DESCRIPTION
Only displays the estimated time metadata in multiple-choice questions if the `estimatedTimeSeconds` property exists.

Relates to #201